### PR TITLE
Add phone field to prescriber forms and filters

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -198,6 +198,7 @@ export function fetchPrescriber(uuid) {
             uuid
             code
             lastName,
+            nin,
             otherNames,
             phone,
             entryDate,
@@ -207,7 +208,7 @@ export function fetchPrescriber(uuid) {
             mainHealthFacility { uuid name code },
             authorizedHealthFacilities { uuid name code },
             speciality { uuid speciality code },
-            status { code status }
+            status { code status altLanguage }
           }
         }
       }
@@ -248,7 +249,7 @@ export function formatPrescriber(prescriber) {
     ${!!prescriber.mainHealthFacility ? `mainHealthFacilityUuid: "${prescriber.mainHealthFacility.uuid}"` : ""}
     ${!!prescriber.authorizedHealthFacilities ? formatAuthorizedHealthFacilitiesUuids(prescriber.authorizedHealthFacilities) : ""}
     ${!!prescriber.speciality ? `specialityUuid: "${prescriber.speciality.uuid}"` : ""}
-    ${!!prescriber.status ? `statusId: ${prescriber.status}` : ""}
+    ${!!prescriber.status ? `statusId: ${prescriber.status.code}` : ""}
     ${!!prescriber.entryDate ? `entryDate: "${prescriber.entryDate}"` : ""}
     ${!!prescriber.releaseDate ? `releaseDate: "${prescriber.releaseDate}"` : ""}
     ${!!prescriber.jsonExt ? `jsonExt: "${formatGQLString(prescriber.jsonExt)}"` : ""}

--- a/src/components/PrescriberFilter.js
+++ b/src/components/PrescriberFilter.js
@@ -58,7 +58,7 @@ class PrescriberFilter extends Component {
       return {
         id: "status",
         value: v,
-        filter: `status_Code: ${v}`,
+        filter: `status_Code: ${v.code}`,
       };
     } else {
       return { id: "status", value: null, filter: null };
@@ -206,7 +206,7 @@ class PrescriberFilter extends Component {
           }
         />
         <Grid item xs={3} className={classes.item}>
-          <NumberInput
+          <TextInput
             module="claim"
             label="prescriber.code"
             name="code"
@@ -270,6 +270,24 @@ class PrescriberFilter extends Component {
                     id: "nin",
                     value: v,
                     filter: !!v ? `nin_Istartswith: "${v}"` : null,
+                  },
+                ]);
+              }
+            }
+          />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <TextInput
+            module="claim"
+            label="prescriber.phone"
+            name="phone"
+            value={this._filterTextFieldValue("phone")}
+            onChange={(v) => {
+                this.debouncedOnChangeFilter([
+                  {
+                    id: "phone",
+                    value: v,
+                    filter: !!v ? `phone_Istartswith: "${v}"` : null,
                   },
                 ]);
               }

--- a/src/components/PrescriberForm.js
+++ b/src/components/PrescriberForm.js
@@ -103,6 +103,10 @@ class PrescriberForm extends Component {
   };
 
   canSave = () => {
+    if (!this.state.prescriber.code||!this.state.prescriber.lastName||!this.state.prescriber.otherNames||!this.state.prescriber.nin||
+      !this.state.prescriber.status||!this.state.prescriber.speciality||!this.state.prescriber.mainHealthFacility||
+      !this.state.prescriber.entryDate) return false;
+    
     return true;
   };
 

--- a/src/components/PrescriberMasterPanel.js
+++ b/src/components/PrescriberMasterPanel.js
@@ -17,6 +17,7 @@ const styles = (theme) => ({
 class PrescriberMasterPanel extends FormPanel {
   render() {
     const { classes, edited, readOnly = false } = this.props;
+    console.log(edited);
     return (
       <Grid container>
         <ControlledField
@@ -57,6 +58,7 @@ class PrescriberMasterPanel extends FormPanel {
                     pubRef="location.HealthFacilityPicker"
                     value={edited.mainHealthFacility}
                     region={edited.region}
+                    required={true}
                     district={edited.district}
                     onChange={(v) => this.updateAttribute("mainHealthFacility",v)}
                 />
@@ -69,7 +71,7 @@ class PrescriberMasterPanel extends FormPanel {
             id="prescriber.code"
             field={
                 <Grid item xs={3} className={classes.item}>
-                    <NumberInput
+                    <TextInput
                         module="claim"
                         label="prescriber.code"
                         name="code"
@@ -94,6 +96,7 @@ class PrescriberMasterPanel extends FormPanel {
                 module="claim"
                 label="prescriber.lastName"
                 name="lastName"
+                required={true}
                 value={edited.lastName}
                 onChange={(v) => this.updateAttribute("lastName",v) }
             />
@@ -107,6 +110,7 @@ class PrescriberMasterPanel extends FormPanel {
                 <Grid item xs={3} className={classes.item}>
                     <TextInput
                     module="claim"
+                    required={true}
                     label="prescriber.otherNames"
                     name="otherNames"
                     value={edited.otherNames}
@@ -123,10 +127,27 @@ class PrescriberMasterPanel extends FormPanel {
                 <Grid item xs={3} className={classes.item}>
                     <NumberInput
                     module="claim"
+                    required={true}
                     label="prescriber.nin"
                     name="nin"
                     value={edited.nin}
                     onChange={(v) => this.updateAttribute("nin",v) }
+                    />
+                </Grid>
+            }
+        />
+        <ControlledField
+            module="claim"
+            id="prescrber.phone"
+            field={
+                <Grid item xs={3} className={classes.item}>
+                    <TextInput
+                    module="claim"
+                    required={true}
+                    label="prescriber.phone"
+                    name="phone"
+                    value={edited.phone}
+                    onChange={(v) => this.updateAttribute("phone",v) }
                     />
                 </Grid>
             }
@@ -138,6 +159,7 @@ class PrescriberMasterPanel extends FormPanel {
             field={
                 <Grid item xs={3} className={classes.item}>
                     <PublishedComponent
+                    required={true}
                     pubRef="claim.StatusPicker"
                     value={edited.status}
                     onChange={(v) => this.updateAttribute("status",v)}
@@ -152,6 +174,7 @@ class PrescriberMasterPanel extends FormPanel {
             field={
                 <Grid item xs={3} className={classes.item}>
                     <PublishedComponent
+                    required={true}
                     pubRef="claim.SpecialityPicker"
                     value={edited.speciality}
                     onChange={(v) => this.updateAttribute("speciality",v)}
@@ -169,6 +192,7 @@ class PrescriberMasterPanel extends FormPanel {
                         pubRef="core.DatePicker"
                         value={edited.entryDate}
                         module="claim"
+                        required={true}
                         label="prescriber.entryDate"
                         onChange={(v) => this.updateAttribute("entryDate",v) }
                     />

--- a/src/components/PrescribersSearcher.js
+++ b/src/components/PrescribersSearcher.js
@@ -54,6 +54,7 @@ class PrescribersSearcher extends Component {
   headers = () => {
     let headers = [
       "prescriber.code",
+      "prescriber.phone",
       "prescriber.nin",
       "prescriber.lastName",
       "prescriber.otherNames",
@@ -72,6 +73,7 @@ class PrescribersSearcher extends Component {
 
   sorts = () => [
     ["code", true],
+    ["phone",false]
     ["nin", true],
     ["last_name", true],
     ["other_names", true],
@@ -86,6 +88,7 @@ class PrescribersSearcher extends Component {
   itemFormatters = () => {
     let formatters = [
       (prescriber) => prescriber.code,
+      (prescriber) => prescriber.phone,
       (prescriber) => prescriber.nin,
       (prescriber) => prescriber.lastName,
       (prescriber) => prescriber.otherNames,

--- a/src/pickers/StatusPicker.js
+++ b/src/pickers/StatusPicker.js
@@ -33,10 +33,12 @@ class StatusPicker extends Component {
       required = false,
       withNull = true,
     } = this.props;
-    
+  
+    console.log("PROPS",value)
+
     const options = !!status ? 
       status.map((v) => ({
-        value: v.code, 
+        value: v, 
         label: v.status,
         status: v
       })) : [];


### PR DESCRIPTION
Introduces the phone field to prescriber-related components, including forms, filters, and searchers. Updates validation to require the phone field and adjusts GraphQL queries and formatting to support the new field. Also changes code input from NumberInput to TextInput for better flexibility.